### PR TITLE
feat: adiciona log de requisicoes HTTP

### DIFF
--- a/src/common/middleware/request-logger.middleware.ts
+++ b/src/common/middleware/request-logger.middleware.ts
@@ -1,0 +1,38 @@
+import { Injectable, Logger, NestMiddleware } from '@nestjs/common';
+import { NextFunction, Request, Response } from 'express';
+
+/**
+ * Loga uma linha por requisição: método, rota, status e duração.
+ *
+ * É middleware — e não interceptor — de propósito: middleware roda antes dos
+ * guards, e o evento 'finish' dispara depois que a resposta saiu. Isso cobre
+ * respostas que nunca chegam ao controller (401 do JwtAuthGuard, 400 do
+ * ValidationPipe, 404 de rota inexistente), que um interceptor não enxergaria.
+ */
+@Injectable()
+export class RequestLoggerMiddleware implements NestMiddleware {
+  private readonly logger = new Logger('HTTP');
+
+  use(req: Request, res: Response, next: NextFunction) {
+    const inicio = Date.now();
+
+    res.on('finish', () => {
+      const duracao = Date.now() - inicio;
+
+      // Só metadados: body e header Authorization carregam senha e token,
+      // e o log vai parar no stdout do Railway.
+      const linha = `${req.method} ${req.originalUrl} ${res.statusCode} - ${duracao}ms`;
+
+      if (res.statusCode >= 500) {
+        this.logger.error(linha);
+      } else if (res.statusCode >= 400) {
+        // warn deixa os 4xx visíveis: o HttpExceptionFilter responde sem logar nada.
+        this.logger.warn(linha);
+      } else {
+        this.logger.log(linha);
+      }
+    });
+
+    next();
+  }
+}

--- a/src/common/middleware/request-logger.middleware.ts
+++ b/src/common/middleware/request-logger.middleware.ts
@@ -3,11 +3,6 @@ import { NextFunction, Request, Response } from 'express';
 
 /**
  * Loga uma linha por requisição: método, rota, status e duração.
- *
- * É middleware — e não interceptor — de propósito: middleware roda antes dos
- * guards, e o evento 'finish' dispara depois que a resposta saiu. Isso cobre
- * respostas que nunca chegam ao controller (401 do JwtAuthGuard, 400 do
- * ValidationPipe, 404 de rota inexistente), que um interceptor não enxergaria.
  */
 @Injectable()
 export class RequestLoggerMiddleware implements NestMiddleware {
@@ -18,15 +13,11 @@ export class RequestLoggerMiddleware implements NestMiddleware {
 
     res.on('finish', () => {
       const duracao = Date.now() - inicio;
-
-      // Só metadados: body e header Authorization carregam senha e token,
-      // e o log vai parar no stdout do Railway.
       const linha = `${req.method} ${req.originalUrl} ${res.statusCode} - ${duracao}ms`;
 
       if (res.statusCode >= 500) {
         this.logger.error(linha);
       } else if (res.statusCode >= 400) {
-        // warn deixa os 4xx visíveis: o HttpExceptionFilter responde sem logar nada.
         this.logger.warn(linha);
       } else {
         this.logger.log(linha);

--- a/src/modules/app/app.module.ts
+++ b/src/modules/app/app.module.ts
@@ -34,7 +34,6 @@ import databaseConfig from '../../config/database.config';
 })
 export class AppModule implements NestModule {
   configure(consumer: MiddlewareConsumer) {
-    // '*path' e não '*': o Express 5 (Nest 11) exige curinga nomeado.
     consumer.apply(RequestLoggerMiddleware).forRoutes('*path');
   }
 }

--- a/src/modules/app/app.module.ts
+++ b/src/modules/app/app.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { MiddlewareConsumer, Module, NestModule } from '@nestjs/common';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { AuthModule } from '../auth/auth.module';
@@ -10,6 +10,7 @@ import { EmailModule } from '../email/email.module';
 import { ConfigModule } from '@nestjs/config';
 import { envValidationSchema } from 'src/config/env.validation';
 import { ActivityModule } from '../activity/activity.module';
+import { RequestLoggerMiddleware } from 'src/common/middleware/request-logger.middleware';
 import databaseConfig from '../../config/database.config';
 
 @Module({
@@ -31,4 +32,9 @@ import databaseConfig from '../../config/database.config';
   controllers: [AppController],
   providers: [AppService],
 })
-export class AppModule {}
+export class AppModule implements NestModule {
+  configure(consumer: MiddlewareConsumer) {
+    // '*path' e não '*': o Express 5 (Nest 11) exige curinga nomeado.
+    consumer.apply(RequestLoggerMiddleware).forRoutes('*path');
+  }
+}


### PR DESCRIPTION
Adiciona um middleware global que registra uma linha por requisição:
método, rota, status e duração. Aparece no terminal em dev e no
stdout do Railway em produção.

Antes não havia nenhum log de requisição no projeto — o
ResponseInterceptor só remonta o corpo e o HttpExceptionFilter só
formata o erro, sem escrever nada.

**Por que middleware e não interceptor:** middleware roda antes dos
guards, e o evento `finish` dispara depois que a resposta saiu. Isso
cobre respostas que nunca chegam ao controller — 401 do JwtAuthGuard,
400 do ValidationPipe, 404 de rota inexistente — que um interceptor
não enxergaria.

Os 4xx saem como `warn` justamente porque hoje são invisíveis: o
HttpExceptionFilter responde e não loga.

**Segurança:** só metadados. Body e header `Authorization` ficam de
fora — senha e token trafegam ali, e o log vai parar no stdout do Railway.

Testado localmente numa instância isolada:

LOG  [HTTP] GET  /api/v1/health         200 - 123ms
WARN [HTTP] POST /api/v1/auth/login     400 - 7ms
WARN [HTTP] GET  /api/v1/certificate/me 401 - 2ms
WARN [HTTP] GET  /api/v1/nao-existe     404 - 3ms